### PR TITLE
Completed implementation of usecase - to relay incoming requests to t…

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -58,6 +58,12 @@
 			<groupId>org.springframework.boot</groupId>
 			<artifactId>spring-boot-devtools</artifactId>
 		</dependency>
+		<!-- https://mvnrepository.com/artifact/org.projectlombok/lombok -->
+		<dependency>
+			<groupId>org.projectlombok</groupId>
+			<artifactId>lombok</artifactId>
+			<scope>provided</scope>
+		</dependency>
     </dependencies>
 
     <build>

--- a/src/main/java/au/com/telstra/simcardactivator/SimCardActivator.java
+++ b/src/main/java/au/com/telstra/simcardactivator/SimCardActivator.java
@@ -2,6 +2,9 @@ package au.com.telstra.simcardactivator;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.boot.web.client.RestTemplateBuilder;
+import org.springframework.context.annotation.Bean;
+import org.springframework.web.client.RestTemplate;
 
 @SpringBootApplication
 public class SimCardActivator {
@@ -9,5 +12,10 @@ public class SimCardActivator {
     public static void main(String[] args) {
         SpringApplication.run(SimCardActivator.class, args);
     }
+
+    @Bean
+    RestTemplate restTemplate(RestTemplateBuilder builder) {
+		return builder.build();
+	}
 
 }

--- a/src/main/java/au/com/telstra/simcardactivator/controller/SCAController.java
+++ b/src/main/java/au/com/telstra/simcardactivator/controller/SCAController.java
@@ -1,0 +1,38 @@
+package au.com.telstra.simcardactivator.controller;
+
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import au.com.telstra.simcardactivator.pojo.CreateRequest;
+import au.com.telstra.simcardactivator.service.SCAServiceImpl;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@RestController
+@RequestMapping({"/v1/simcard/activate/","/v1/simcard/activate"})
+@Slf4j
+@RequiredArgsConstructor
+public class SCAController {
+	
+	private final SCAServiceImpl scaService;
+	
+	@PostMapping
+	public String activateSim(
+			@RequestBody CreateRequest requestBody) {
+		log.info("requestBody:{}",requestBody);
+		log.info("Calling activateSim service...");
+		
+		boolean response = scaService.activateSim(requestBody);
+		
+		if(!response) {
+			log.info("Error! Sim activation failed.");
+			return "ERROR! Sim activation was not successful!";
+		}
+		log.info("Sim activation successful. Returning response string.");
+		return "Sim activation was successful!";
+		
+	}
+
+}

--- a/src/main/java/au/com/telstra/simcardactivator/pojo/CreateRequest.java
+++ b/src/main/java/au/com/telstra/simcardactivator/pojo/CreateRequest.java
@@ -1,0 +1,10 @@
+package au.com.telstra.simcardactivator.pojo;
+
+import lombok.Data;
+
+@Data
+public class CreateRequest {
+	private String iccid;
+	private String customerEmail;
+
+}

--- a/src/main/java/au/com/telstra/simcardactivator/pojo/SimRequest.java
+++ b/src/main/java/au/com/telstra/simcardactivator/pojo/SimRequest.java
@@ -1,0 +1,10 @@
+package au.com.telstra.simcardactivator.pojo;
+
+import lombok.Data;
+
+@Data
+public class SimRequest {
+	
+	private String iccid;
+
+}

--- a/src/main/java/au/com/telstra/simcardactivator/pojo/SimResponse.java
+++ b/src/main/java/au/com/telstra/simcardactivator/pojo/SimResponse.java
@@ -1,0 +1,9 @@
+package au.com.telstra.simcardactivator.pojo;
+
+import lombok.Data;
+
+@Data
+public class SimResponse {
+	private boolean success;
+
+}

--- a/src/main/java/au/com/telstra/simcardactivator/service/SCAService.java
+++ b/src/main/java/au/com/telstra/simcardactivator/service/SCAService.java
@@ -1,0 +1,9 @@
+package au.com.telstra.simcardactivator.service;
+
+import au.com.telstra.simcardactivator.pojo.CreateRequest;
+
+public interface SCAService {
+	
+	public boolean activateSim(CreateRequest requestBody);
+
+}

--- a/src/main/java/au/com/telstra/simcardactivator/service/SCAServiceImpl.java
+++ b/src/main/java/au/com/telstra/simcardactivator/service/SCAServiceImpl.java
@@ -1,0 +1,50 @@
+package au.com.telstra.simcardactivator.service;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+import org.springframework.web.client.RestTemplate;
+
+import au.com.telstra.simcardactivator.pojo.CreateRequest;
+import au.com.telstra.simcardactivator.pojo.SimRequest;
+import au.com.telstra.simcardactivator.pojo.SimResponse;
+import lombok.extern.slf4j.Slf4j;
+
+@Service
+@Slf4j
+public class SCAServiceImpl implements SCAService{
+	
+	@Autowired
+	private RestTemplate restTemplate;
+	
+
+	@Override
+	public boolean activateSim(CreateRequest requestBody) {
+		
+		log.info("Inside activateSim service...");
+		
+		SimRequest simRequest = new SimRequest();
+		simRequest.setIccid(requestBody.getIccid());
+		
+		log.info("simRequest:{}",simRequest);
+		
+//		HttpHeaders headers = new HttpHeaders();
+//        headers.setContentType(MediaType.APPLICATION_JSON);
+//        log.info("headers:{}",headers);
+        
+//        HttpEntity<SimRequest> entity = new HttpEntity<>(simRequest, headers);
+//        log.info("entity:{}",entity);
+		SimResponse simResponse =null;
+		try {
+		    simResponse = restTemplate.postForObject("http://localhost:8444/actuate", simRequest, SimResponse.class);
+		    log.info("Response: {}", simResponse);
+		} catch (Exception e) {
+		    log.error("Error calling endpoint", e);
+		}
+		
+//		SimResponse simResponse = response.getBody();
+//		log.info("simResponse:{}",simResponse);
+		
+		return simResponse.isSuccess();
+	}
+
+}


### PR DESCRIPTION
Your microservice will need to expose a REST controller that accepts post requests to activate SIM cards. These requests will contain JSON payloads including the SIM ICCID and the customer’s email address with the following structure:

{
"iccid": string,
“customerEmail”: string,
}

The ICCID of a SIM card is the unique global identifier used to route traffic to and from the phone it inhabits. Upon receiving such a request, your application will submit a post request to another microservice running on your machine. This microservice is called the actuator and is responsible for the actual activation of SIM cards. The actuator is supplied as a JAR file in the services folder and can be run with a Java 11 JRE. Executing this programme will start a local server on port 8444 which accepts post requests to the endpoint “http://localhost:8444/actuate” with JSON payloads in the following format:

{
"iccid": string
}

The actuator will return a response with a JSON body of the form:

{
"success": boolean
}

If the activation of the SIM card is a success, this parameter will be true. If it fails, the parameter will be false. For now, your task is to relay incoming requests to this endpoint and print whether or not they were successful.